### PR TITLE
never import *

### DIFF
--- a/src/pypeflow/controller.py
+++ b/src/pypeflow/controller.py
@@ -26,7 +26,7 @@
 PypeController: This module provides the PypeWorkflow that controlls how a workflow is excuted.
 
 """
-
+import sys
 import datetime
 import multiprocessing
 import threading 
@@ -36,9 +36,9 @@ import Queue
 from cStringIO import StringIO 
 from urlparse import urlparse
 
-from common import * 
+from common import PypeError, PypeObject, Graph, URIRef, pypeNS
 from data import PypeDataObjectBase, PypeSplittableLocalFile
-from task import *
+from task import PypeTaskBase, PypeTaskCollection, PypeThreadTaskBase, getFOFNMapTasks
 
 logger = logging.getLogger(__name__)
 

--- a/src/pypeflow/data.py
+++ b/src/pypeflow/data.py
@@ -32,7 +32,7 @@ PypeData: This module defines the general interface and class for PypeData Objec
 from urlparse import urlparse, urljoin
 import platform
 import os, shutil
-from common import * 
+from common import pypeNS, PypeObject, PypeError, NotImplementedError
 import logging
     
 logger = logging.getLogger(__name__)

--- a/src/pypeflow/task.py
+++ b/src/pypeflow/task.py
@@ -45,10 +45,8 @@ else:
 import os
 import shlex
 
-from common import * 
-from data import FileNotExistError
-from data import PypeSplittableLocalFile
-from data import makePypeLocalFile
+from common import PypeError, PypeObject, pypeNS, runShellCmd, Graph, URIRef, Literal
+from data import FileNotExistError, PypeSplittableLocalFile, makePypeLocalFile
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This also fixes a bug in ea8d7ec (missing `sys`) which was hidden by the `*` imports.