### PR TITLE
Better time stamp compare

### DIFF
--- a/src/pypeflow/task.py
+++ b/src/pypeflow/task.py
@@ -831,19 +831,25 @@ def timeStampCompare( inputDataObjs, outputDataObjs, parameters) :
 
     inputDataObjsTS = []
     for ft, f in inputDataObjs.iteritems():
-        inputDataObjsTS.append( f.timeStamp )
+        inputDataObjsTS.append((f.timeStamp, 'A', f))
 
     outputDataObjsTS = []
-
     for ft, f in outputDataObjs.iteritems():
         if not f.exists:
             runFlag = True
             break
         else:
-            outputDataObjsTS.append( f.timeStamp )
+            # 'A' < 'B', so outputs are 'later' if timestamps match.
+            outputDataObjsTS.append((f.timeStamp, 'B', f))
 
-    if runFlag == False:                
-        if min(outputDataObjsTS) < max(inputDataObjsTS):
+    if not outputDataObjs:
+        # 0 outputs => always run
+        runFlag = True
+
+    if not runFlag and inputDataObjs: # 0 inputs would imply that existence of outputs is enough.
+        minOut = min(outputDataObjsTS)
+        maxIn = max(inputDataObjsTS)
+        if minOut < maxIn:
             runFlag = True
 
     return runFlag

--- a/src/pypeflow/task.py
+++ b/src/pypeflow/task.py
@@ -836,6 +836,7 @@ def timeStampCompare( inputDataObjs, outputDataObjs, parameters) :
     outputDataObjsTS = []
     for ft, f in outputDataObjs.iteritems():
         if not f.exists:
+            logger.debug('output does not exist yet: %r'%f)
             runFlag = True
             break
         else:
@@ -850,6 +851,7 @@ def timeStampCompare( inputDataObjs, outputDataObjs, parameters) :
         minOut = min(outputDataObjsTS)
         maxIn = max(inputDataObjsTS)
         if minOut < maxIn:
+            logger.debug('timestamp of output < input: %r < %r'%(minOut, maxIn))
             runFlag = True
 
     return runFlag


### PR DESCRIPTION
This improves the timestamp-checking when there are 0 input or 0 outputs.

It also adds some debug logging to explain *why* the task needs to be run. For that, we need to record filenames along with timestamp, to report which one lead to an inequality. Python can sort tuples, so we record the filename as the last element. The 'A' and 'B' in the tuples are in case an input and output have identical timestamps.