### PR TITLE
Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+# Build matrix / environment variable are explained on:
+# http://about.travis-ci.org/docs/user/build-configuration/
+# This file can be validated on:
+# http://lint.travis-ci.org/
+
+#before_install: sudo apt-get install -y cmake
+# cmake is pre-installed in Travis for both linux and osx
+
+#before_install:
+#  - sudo apt-get update -qq
+#  - sudo apt-get install -qq valgrind
+sudo: required
+os:
+  - linux
+language: python
+#compiler:
+#  - gcc
+#  - clang
+script: ./travis.sh
+#env:
+#  matrix:
+#    - SHARED_LIB=ON  STATIC_LIB=ON CMAKE_PKG=ON  BUILD_TYPE=release VERBOSE_MAKE=false
+#    - SHARED_LIB=OFF STATIC_LIB=ON CMAKE_PKG=OFF BUILD_TYPE=debug   VERBOSE_MAKE=true VERBOSE
+notifications:
+  email: false

--- a/src/pypeflow/controller.py
+++ b/src/pypeflow/controller.py
@@ -169,7 +169,7 @@ class PypeWorkflow(PypeObject):
     >>> from pypeflow.task import *
     >>> try:
     ...     os.makedirs("/tmp/pypetest")
-    ...     os.system("rm /tmp/pypetest/*")
+    ...     _ = os.system("rm -f /tmp/pypetest/*")
     ... except:
     ...     pass
     >>> time.sleep(1)

--- a/src/pypeflow/task.py
+++ b/src/pypeflow/task.py
@@ -419,28 +419,30 @@ class PypeTaskCollection(PypeObject):
     def __getitem__(self, k):
         return self._tasks[k]
 
-_auto_urls = set()
-def _auto_task_url(taskFun):
+_auto_names = set()
+def _unique_name(name):
     """
     >>> def foo(): pass
-    >>> _auto_task_url(foo)
-    'task://<doctest __main__._auto_task_url[0]>/foo'
-    >>> _auto_task_url(foo)
-    'task://<doctest __main__._auto_task_url[0]>/foo.01'
-    >>> _auto_task_url(foo)
-    'task://<doctest __main__._auto_task_url[0]>/foo.02'
+    >>> _unique_name('foo')
+    'foo'
+    >>> _unique_name('foo')
+    'foo.01'
+    >>> _unique_name('foo')
+    'foo.02'
     """
-    url = "task://" + inspect.getfile(taskFun) + "/"+ taskFun.func_name
-    if url in _auto_urls:
+    if name in _auto_names:
         n = 0
         while True:
             n += 1
-            try_url = '%s.%02d' %(url, n)
-            if try_url not in _auto_urls:
+            try_name = '%s.%02d' %(name, n)
+            if try_name not in _auto_names:
                 break
-        url = try_url
-    _auto_urls.add(url)
-    return url
+        name = try_name
+    _auto_names.add(name)
+    return name
+def _auto_task_url(taskFun):
+    # Note: in doctest, the filename would be weird.
+    return "task://" + inspect.getfile(taskFun) + "/"+ _unique_name(taskFun.func_name)
 
 def PypeTask(*argv, **kwargv):
 

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# -e: fail on error
+# -v: show commands
+# -x: show expanded commands
+set -vex
+
+#env | sort
+sudo mkdir -p /tmp
+sudo chmod a+wrx /tmp
+python setup.py install
+nosetests --with-doctest -v src


### PR DESCRIPTION
This is currently configured to run only for pull-requests, not for every push.

Because the tests use `/tmp`, they cannot run in Docker on Travis, so I had to use `sudo`. It takes several extra minutes to acquire a machine with sudo access. We'll worry about that some other time.