### PR TITLE
Skip "already done" tasks -- 10x faster restart

### DIFF
--- a/src/pypeflow/controller.py
+++ b/src/pypeflow/controller.py
@@ -192,7 +192,7 @@ class PypeWorkflow(PypeObject):
     >>> wf.refreshTargets( objs = [fout] )
     /tmp/pypetest/testfile_in
     /tmp/pypetest/testfile_out
-    in finalize: TaskDone
+    in finalize: done
     True
     """
 

--- a/src/pypeflow/task.py
+++ b/src/pypeflow/task.py
@@ -147,6 +147,9 @@ class PypeTaskBase(PypeObject):
 
         return runFlag
 
+    def isSatisfied(self, *argv, **kwargv):
+        return not self._getRunFlag(*argv, **kwargv)
+
     def _runTask(self, *argv, **kwargv):
 
         """ 

--- a/src/pypeflow/task.py
+++ b/src/pypeflow/task.py
@@ -478,8 +478,6 @@ def PypeTask(*argv, **kwargv):
     False
     >>> print test._getRunFlag()
     False
-    >>> test() #return False, the task is no run 
-    False
     >>> print test.a
     I am "a"
     >>> print test.b
@@ -603,7 +601,7 @@ def PypeShellTask(*argv, **kwargv):
     >>> print shellTask._getRunFlag()
     False
     >>> shellTask()
-    False
+    True
     """
 
     def f(scriptToRun):

--- a/src/tests/test_pypeflow_controller.py
+++ b/src/tests/test_pypeflow_controller.py
@@ -330,7 +330,7 @@ class TestPypeThreadWorkflow:
                 l = l.strip()
                 assert l in outputSet
                 i += 1
-            assert i == 3
+            assert_equal(i, 3)
 
     def test_stateDataObjects(self):
 


### PR DESCRIPTION
Ok. Here is the real change. Currently, pypeflow wastes time on subsequent calls to `refreshTargets()` by creating a thread for tasks finished during the loop of the previous call. This change skips those tasks. I have some runtime statistics (representative over several runs):
```
Running in /tmp...

New:

real    0m25.067s
user    0m41.803s
sys     0m58.847s

Or in lustre:

real    0m41.205s
user    0m52.374s
sys     3m48.944s
```
```
Old:

real    0m40.859s
user    0m48.218s
sys     1m1.483s

Or in lustre:

real    0m51.425s
user    0m48.011s
sys     1m9.026s
```
On a restart, with all tasks finished...
```
New:

real    0m3.601s
user    0m2.936s
sys     0m0.604s

Or in lustre:

real    0m3.912s
user    0m2.710s
sys     0m0.690s

% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 40.72    0.285451        3069        93           wait4
 19.38    0.135872          24      5609      5142 open
 10.80    0.075701          11      6881      1448 stat
  7.27    0.050939          10      5321           read
  5.78    0.040507         436        93           clone
```
```
Old:

real    0m25.963s
user    0m19.600s
sys     0m10.634s

Or in lustre:

real    0m28.170s
user    0m19.609s
sys     0m12.247s

% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 75.57    1.716911          15    113490     12637 futex
 11.96    0.271850        2923        93           wait4
  4.21    0.095652          17      5608      5142 open
  2.45    0.055562          71       782           clone
  1.54    0.035070          17      2050      1448 stat
  1.41    0.032083           6      5318           read
```
I'll try to explain. The `futex` is a Linux O/S low-level operation, used by mutexes e.g. It seems to be used (indirectly) by Python via some kind of interaction with threads. I'm not sure whether it's from the thread-safe queue, or thread-creation, or thread-joining, but it's definitely caused by the sheer number of threads.

In the example above, I have forced my tiny test-case (5000 random nucleotides, sampled randomly with 20x coverage) to use a large number of jobs (91 in this case) by using my custom flag within **daligner/dazzler** (`DBsplit -uN`) to force super-small blocks. This way, I can get as many jobs as I choose, and I still have a strong regression-test on the final result with a reasonably quick runtime. (It takes more time to explain the test than to run it!)

It turns out that threads are expensive. That's not to condemn pypeflow. On the contrary, it's a good architecture. But its weaknesses should be understood. We had assumed that the main part of the runtime on a restart of fully completed tasks would be `stat` calls. Well, that turns out to be wrong. The threads themselves are more expensive. So it is helpful to avoid starting those threads at all when a task is already done.

For the normal workflow, this makes a difference, but not a huge one. The difference is much greater in `/tmp` than in **lustre**. (I'll explain why later.) But it's small enough to ignore.

However, when *restarting* pypeflow, the difference is significant. Extrapolating to 1000 jobs, the difference would be 30seconds vs. 5minutes or more. (dgordon experienced hours instead of minutes because of my symlinking bug.) This might not matter to most people, but it matters to me. A restart should be very fast.

The reason the difference is greater on the local disk than in **lustre** is that I have somehow tripled the number of `stat` calls, as can be seen from the **strace** results above. (It's actually 6x in the normal case.) I'm not merging this right away because I'd like to track that down. (I have a theory.)

And even without the extra stat-calls, this change is worth reviewing.

The `#del thread` lines turn out to have no impact, which is why they are commented out, but I will uncomment them later since they are more correct for Ctrl-C handling.