### PR TITLE
Fix an issue with submitting jobs using bsub

### DIFF
--- a/pwatcher/fs_based.py
+++ b/pwatcher/fs_based.py
@@ -398,7 +398,7 @@ class MetaJobLsf(object):
         return 'MetaJobLsf(%s)' %repr(self.mjob)
     def __init__(self, mjob):
         self.mjob = mjob
-        self.specific = '-V' # pass enV; '-j y' => combine out/err
+        self.specific = '' # pass enV; '-j y' => combine out/err
 
 def link_rundir(state_rundir, user_rundir):
     if user_rundir:


### PR DESCRIPTION
With -V option, bsub will output the version number and exit without running the job at all (unlike the -V options for qsub).