### PR TITLE
Simpler pypeflow

### DIFF
--- a/pwatcher/blocking.py
+++ b/pwatcher/blocking.py
@@ -290,7 +290,8 @@ def cmd_run(state, jobids, job_type, job_queue):
     jobs = dict()
     submitted = list()
     result = {'submitted': submitted}
-    assert job_type == 'string'
+    if job_type != 'string':
+        log.warning("In blocking pwatcher, job_type={!r}, should be 'string'".format(job_type))
     for jobid, desc in jobids.iteritems():
         assert 'cmd' in desc
         cmd = desc['cmd']

--- a/pwatcher/mains/job_start.sh
+++ b/pwatcher/mains/job_start.sh
@@ -18,12 +18,16 @@
 
 set -vex
 executable=${PYPEFLOW_JOB_START_SCRIPT}
-timeout=${PYPEFLOW_JOB_START_TIMEOUT:-120} # wait 2 mins by default
+timeout=${PYPEFLOW_JOB_START_TIMEOUT:-60} # wait 60s by default
 
 # Wait up to timeout seconds for the executable to become "executable",
 # then exec.
 #timeleft = int(timeout)
-while [[ ! -x "${executable}" && "${timeout}" != "0" ]]; do
+while [[ ! -x "${executable}" ]]; do
+    if [[ "${timeout}" == "0" ]]; then
+        echo "timed out waiting for (${executable})"
+        exit 77
+    fi
     echo "not executable: '${executable}', waiting ${timeout}s"
     sleep 1
     timeout=$((timeout-1))

--- a/pypeflow/do_support.py
+++ b/pypeflow/do_support.py
@@ -44,7 +44,7 @@ def run_bash(script_fn):
     # available in the filesystem.
     # However, we cannot be sure that the execute permission is set,
     # so run it as a script.
-    cmd = '{} {}'.format(BASH, script_fn)
+    cmd = '{} -vex {}'.format(BASH, script_fn)
     LOG.info('!{}'.format(cmd))
     rc = os.system(cmd)
     if rc:

--- a/pypeflow/do_support.py
+++ b/pypeflow/do_support.py
@@ -1,0 +1,51 @@
+import logging
+import logging.config
+import os
+import string
+import StringIO
+LOG = logging.getLogger(__name__)
+BASH = '/bin/bash'
+
+# This is used by some programs in falcon_kit/mains.
+simple_logging_config = """
+[loggers]
+keys=root
+
+[handlers]
+keys=stream
+
+[formatters]
+keys=form01,form02
+
+[logger_root]
+level=NOTSET
+handlers=stream
+
+[handler_stream]
+class=StreamHandler
+level=${FALCON_LOG_LEVEL}
+formatter=form01
+args=(sys.stderr,)
+
+[formatter_form01]
+format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
+
+[formatter_form02]
+format=[%(levelname)s]%(message)s
+"""
+def setup_simple_logging(FALCON_LOG_LEVEL='DEBUG', **ignored):
+    cfg = string.Template(simple_logging_config).substitute(FALCON_LOG_LEVEL=FALCON_LOG_LEVEL)
+    logger_fileobj = StringIO.StringIO(cfg)
+    defaults = {}
+    logging.config.fileConfig(logger_fileobj, defaults=defaults, disable_existing_loggers=False)
+
+def run_bash(script_fn):
+    # Assume script was written by this program, so we know it is
+    # available in the filesystem.
+    # However, we cannot be sure that the execute permission is set,
+    # so run it as a script.
+    cmd = '{} {}'.format(BASH, script_fn)
+    LOG.info('!{}'.format(cmd))
+    rc = os.system(cmd)
+    if rc:
+        raise Exception('{} <- {!r}'.format(rc, cmd))

--- a/pypeflow/do_task.py
+++ b/pypeflow/do_task.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python2.7
+from . import do_support
+import argparse
+import contextlib
+import importlib
+import inspect
+import json
+import logging
+import os
+import pprint
+import sys
+import time
+DONE = 'done'
+STATUS = 'status'
+TIMEOUT = 0
+LOG = logging.getLogger()
+DESCRIPTION = """Given a JSON description, call a python-function.
+"""
+EPILOG = """
+The JSON looks like this:
+{
+    "inputs": {"input-name": "filename"},
+    "outputs": {"output-name": "output-filename (relative)"},
+    "python_function": "falcon_kit.mains.foo",
+    "parameters": {}
+}
+
+This program will run on the work host, and it will do several things:
+    - Run in CWD.
+    - Verify that inputs are available. (Wait til timeout if not.)
+    - Possibly, cd to tmpdir and create symlinks from inputs.
+    - Run the python-module.
+      - Pass a kwd-dict of the union of inputs/outputs/parameters.
+      - Ignore return-value. Expect exceptions.
+    - Possibly, mv outputs from tmpdir to workdir.
+    - Write exit-code into STATUS.
+    - Touch DONE on success.
+"""
+"""
+(Someday, we might also support runnable Python modules, or even executables via execvp().)
+
+Note: qsub will *not* run this directly. There is a higher layer.
+"""
+"""
+"""
+
+def get_parser():
+    class _Formatter(argparse.RawDescriptionHelpFormatter, argparse.ArgumentDefaultsHelpFormatter):
+        pass
+    parser = argparse.ArgumentParser(description=DESCRIPTION, epilog=EPILOG,
+        formatter_class=_Formatter,
+    )
+    parser.add_argument('--timeout',
+        type=int, default=60,
+        help='How many seconds to wait for input files (and JSON) to exist. (default: %(default)s')
+    parser.add_argument('--tmpdir',
+        help='Root directory to run in. (Sub-dir name will be based on CWD.)')
+    parser.add_argument('json_fn',
+        help='JSON file, as per epilog.')
+    return parser
+
+@contextlib.contextmanager
+def cd(newdir):
+    prevdir = os.getcwd()
+    LOG.debug('CD: %r <- %r' %(newdir, prevdir))
+    os.chdir(os.path.expanduser(newdir))
+    try:
+        yield
+    finally:
+        LOG.debug('CD: %r -> %r' %(newdir, prevdir))
+        os.chdir(prevdir)
+
+def mkdirs(path):
+    if not os.path.isdir(path):
+        os.makedirs(path)
+
+def wait_for(fn):
+    global TIMEOUT
+    LOG.debug('Checking existence of {!r}'.format(fn))
+    while not os.path.exists(fn):
+        if TIMEOUT > 0:
+            time.sleep(1)
+            TIMEOUT -= 1
+        else:
+            raise Exception('Timed out waiting for {!r}'.format(fn))
+    assert os.access(fn, os.R_OK), '{!r} not readable'.format(fn)
+
+def get_func(python_function):
+    mod_name, func_name = os.path.splitext(python_function)
+    func_name = func_name[1:] # skip dot
+    mod = importlib.import_module(mod_name)
+    func = getattr(mod, func_name)
+    return func
+
+class OldTaskRunner(object):
+    def __init__(self, inputs, outputs, parameters):
+        for k,v in (inputs.items() + outputs.items()):
+            setattr(self, k, v)
+        self.parameters = parameters
+        self.inputs = inputs
+        self.outputs = outputs
+
+def run(json_fn, timeout, tmpdir):
+    if isinstance(timeout, int):
+        global TIMEOUT
+        TIMEOUT = timeout
+    wait_for(json_fn)
+    LOG.debug('Loading JSON from {!r}'.format(json_fn))
+    cfg = json.loads(open(json_fn).read())
+    LOG.debug(pprint.pformat(cfg))
+    for fn in cfg['inputs'].values():
+        wait_for(fn)
+    python_function_name = cfg['python_function']
+    func = get_func(python_function_name)
+    try:
+        if False:
+            kwds = dict()
+            kwds.update(cfg['inputs'])
+            kwds.update(cfg['outputs'])
+            kwds.update(cfg['parameters'])
+            func(**kwds)
+        else:
+            # old way, for now
+            self = OldTaskRunner(cfg['inputs'], cfg['outputs'], cfg['parameters'])
+            func(self=self)
+            script_fn = getattr(self, 'generated_script_fn', None)
+            if script_fn is not None:
+                do_support.run_bash(script_fn)
+    except TypeError:
+        # Report the actual function spec.
+        LOG.error('For function "{}", {}'.format(python_function_name, inspect.getargspec(func)))
+        raise
+
+def main():
+    parser = get_parser()
+    parsed_args = parser.parse_args(sys.argv[1:])
+    try:
+        run(**vars(parsed_args))
+    except Exception:
+        LOG.critical('Error in {} with args={!r}'.format(sys.argv[0], pprint.pformat(vars(parsed_args))))
+        raise
+
+if __name__ == "__main__":
+    do_support.setup_simple_logging(**os.environ)
+    LOG.debug('Running "{}"'.format(' '.join(sys.argv)))
+    main()

--- a/pypeflow/do_task.py
+++ b/pypeflow/do_task.py
@@ -29,7 +29,8 @@ This program will run on the work host, and it will do several things:
     - Run in CWD.
     - Verify that inputs are available. (Wait til timeout if not.)
     - Possibly, cd to tmpdir and create symlinks from inputs.
-    - Run the python-module.
+    - Run the python-function.
+      - Its module must be available (e.g. in PYTHONPATH).
       - Pass a kwd-dict of the union of inputs/outputs/parameters.
       - Ignore return-value. Expect exceptions.
     - Possibly, mv outputs from tmpdir to workdir.
@@ -40,8 +41,6 @@ This program will run on the work host, and it will do several things:
 (Someday, we might also support runnable Python modules, or even executables via execvp().)
 
 Note: qsub will *not* run this directly. There is a higher layer.
-"""
-"""
 """
 
 def get_parser():

--- a/pypeflow/pwatcher_bridge.py
+++ b/pypeflow/pwatcher_bridge.py
@@ -38,7 +38,7 @@ def PypeProcWatcherWorkflow(
     """Factory for the workflow using our new
     filesystem process watcher.
     """
-    if job_type == 'string' or watcher_type == 'string':
+    if watcher_type == 'blocking':
         pwatcher_impl = pwatcher.blocking
     elif watcher_type == 'network_based':
         pwatcher_impl = pwatcher.network_based

--- a/pypeflow/pwatcher_bridge.py
+++ b/pypeflow/pwatcher_bridge.py
@@ -44,7 +44,10 @@ def PypeProcWatcherWorkflow(
         pwatcher_impl = pwatcher.network_based
     else:
         pwatcher_impl = pwatcher.fs_based
+    log.warning('In pwatcher_bridge, pwatcher_impl={!r}'.format(pwatcher_impl))
+    log.info('In pwatcher_bridge, pwatcher_impl={!r}'.format(pwatcher_impl))
     watcher = pwatcher_impl.get_process_watcher(watcher_directory)
+    log.info('job_type={!r}, job_queue={!r}'.format(job_type, job_queue))
     th = MyPypeFakeThreadsHandler(watcher, job_type, job_queue)
     mq = MyMessageQueue()
     se = MyFakeShutdownEvent() # TODO: Save pwatcher state on ShutdownEvent. (Not needed for blocking pwatcher. Mildly useful for fs_based.)

--- a/pypeflow/simple_pwatcher_bridge.py
+++ b/pypeflow/simple_pwatcher_bridge.py
@@ -1,369 +1,392 @@
-"""Bridge pattern to adapt pypeFLOW with pwatcher.
-
-This is a bit messy, but it avoids re-writing the useful bits
-of pypeFLOW.
-
-With PypeProcWatcherWorkflow, the refreshTargets() loop will
-be single-threaded!
-"""
 from pwatcher import fs_based
-from pypeflow.task import PypeTask, PypeThreadTaskBase, PypeTaskBase, TaskFunctionError
-import pypeflow.controller
-import pypeflow.task
+from .util import (mkdirs, system, touch, run, cd)
+import networkx
+import networkx.algorithms.dag #import (topological_sort, is_directed_acyclic_graph)
+
 import collections
-import datetime
-import glob
-import hashlib
-import json
 import logging
 import os
 import pprint
-import re
-import sys
+import random
 import time
-import traceback
 
-log = logging.getLogger(__name__)
+LOG = logging.getLogger()
 
-def PypeProcWatcherWorkflow(
-        URL = None,
-        job_type='local',
-        job_queue='UNSPECIFIED_QUEUE',
-        **attributes):
-    """Factory for the workflow using our new
-    filesystem process watcher.
+# These globals exist only to support the old PypeTask API,
+# which relies on inputs/outputs instead of direct Node dependencies.
+PRODUCER = dict()
+CONSUMERS = collections.defaultdict(set)
+
+def endrun(thisnode, status):
+    """By convention for now, status is one of:
+        'DEAD'
+        'UNSUBMITTED' (a pseudo-status defined in the ready-loop of alive())
+        'EXIT rc'
     """
-    th = MyPypeFakeThreadsHandler('mypwatcher', job_type, job_queue)
-    mq = MyMessageQueue()
-    se = MyFakeShutdownEvent()
-    return pypeflow.controller._PypeConcurrentWorkflow(URL=URL, thread_handler=th, messageQueue=mq, shutdown_event=se,
-            attributes=attributes)
-
-PypeProcWatcherWorkflow.setNumThreadAllowed = pypeflow.controller._PypeConcurrentWorkflow.setNumThreadAllowed
-
-class Fred(object):
-    """Fake thread.
-    """
-    INITIALIZED = 10
-    STARTED = 20
-    RUNNING = 30
-    JOINED = 40
-    def is_alive(self):
-        return self.__status in (Fred.STARTED, Fred.RUNNING)
-    def start(self):
-        self.__status = Fred.STARTED
-        self.__th.enqueue(self)
-    def join(self, timeout=None):
-        # Maybe we should wait until the sentinel is visible in the filesystem?
-        # Also, if we were STARTED but not RUNNING, then we never did anything!
-
-        #assert self.__status is not Fred.JOINED # Nope. Might be called a 2nd time by notifyTerminate().
-        self.__status = Fred.JOINED
-    # And our own special methods.
-    def task(self):
-        return self.__target
-    def generate(self):
-        self.__target()
-    def setTargetStatus(self, status):
-        self.__target.setStatus(status)
-    def endrun(self, status):
-        """By convention for now, status is one of:
-            'DEAD'
-            'UNSUBMITTED' (a pseudo-status defined in the ready-loop of alive())
-            'EXIT rc'
-        """
-        name = status.split()[0]
-        if name == 'DEAD':
-            log.warning(''.join(traceback.format_stack()))
-            log.error('Task {}\n is DEAD, meaning no HEARTBEAT, but this can be a race-condition. If it was not killed, then restarting might suffice. Otherwise, you might have excessive clock-skew.'.format(self.brief()))
-            self.setTargetStatus(pypeflow.task.TaskFail) # for lack of anything better
-        elif name == 'UNSUBMITTED':
-            log.warning(''.join(traceback.format_stack()))
-            log.error('Task {}\n is UNSUBMITTED, meaning job-submission somehow failed. Possibly a re-start would work. Otherwise, you need to investigate.'.format(self.brief()))
-            self.setTargetStatus(pypeflow.task.TaskFail) # for lack of anything better
-        elif name != 'EXIT':
-            raise Exception('Unexpected status {!r}'.format(name))
+    name = status.split()[0]
+    if name == 'DEAD':
+        LOG.warning(''.join(traceback.format_stack()))
+        LOG.error('Task {}\n is DEAD, meaning no HEARTBEAT, but this can be a race-condition. If it was not killed, then restarting might suffice. Otherwise, you might have excessive clock-skew.'.format(thisnode))
+        #thisnode.setSatisfied(False) # I think we can leave it unsatisfied. Not sure what happens on retry though.
+    elif name == 'UNSUBMITTED':
+        LOG.warning(''.join(traceback.format_stack()))
+        LOG.error('Task {}\n is UNSUBMITTED, meaning job-submission somehow failed. Possibly a re-start would work. Otherwise, you need to investigate.'.format(thisnode))
+        thisnode.setSatisfied(False)
+    elif name != 'EXIT':
+        raise Exception('Unexpected status {!r}'.format(name))
+    else:
+        code = int(status.split()[1])
+        if 0 != code:
+            LOG.error('Task {} failed with exit-code={}'.format(thisnode, code))
+            thisnode.setSatisfied(False)
         else:
-            code = int(status.split()[1])
-            if 0 == code:
-                self.__target.check_missing()
-                # TODO: If missing, just leave the status as TaskInitialized?
-            else:
-                log.error('Task {} failed with exit-code={}'.format(self.brief(), code))
-                self.setTargetStatus(pypeflow.task.TaskFail) # for lack of anything better
-        self.__target.finish()
-    def brief(self):
-        return 'Fred{}'.format(self.__target.brief())
-    def __repr__(self):
-        return 'FRED with taskObj={!r}'.format(self.__target)
-    def __init__(self, target, th):
-        assert isinstance(target, MyFakePypeThreadTaskBase)
-        self.__target = target # taskObj?
-        self.__th = th # thread handler
-        self.__status = Fred.INITIALIZED
+            thisnode.setSatisfied(True)
 
-class MyMessageQueue(object):
-    def empty(self):
-        return not self.__msgq
-    def get(self):
-        return self.__msgq.popleft()
-    def put(self, msg):
-        self.__msgq.append(msg)
-    def __init__(self):
-        self.__msgq = collections.deque()
-
-class MyFakeShutdownEvent(object):
-    """I do not see any code which actually uses the
-    shutdown_event, but if needed someday, we can use this.
-    """
-    def set(self):
-        pass
-
-_prev_q = {} # To avoid excessive log output.
-
-class MyPypeFakeThreadsHandler(object):
-    """Stateless method delegator, for injection.
-    """
-    def create(self, target):
-        thread = Fred(target=target, th=self)
-        return thread
-    def alive(self, threads):
-        ready = dict()
-        while self.__jobq:
-            fred = self.__jobq.popleft()
-            taskObj = fred.task()
-            fred.generate() # -> taskObj->generated_script_fn by convention
-            #log.info('param:\n%s' %pprint.pformat(taskObj.parameters)) # I do not think these change.
-            try:
-                script_fn = taskObj.generated_script_fn # BY CONVENTION
-            except AttributeError:
-                log.warning('Missing taskObj.generated_script_fn for task. Maybe we did not need it? Skipping and continuing.')
-                fred.endrun('EXIT 0')
+class PwatcherTaskQueue(object):
+    def enque(self, nodes):
+        """This should be an injected dependency.
+        Yield any Nodes that could not be submitted.
+        Nodes that lacked a script were actually run in-process and are considered
+        successful unless they raised an Exception, so they go into the to_report set.
+        """
+        # Start all "nodes".
+        # Note: It is safe to run this block always, but we save a
+        # call to pwatcher with 'if ready'.
+        LOG.debug('enque nodes:\n%s' %pprint.pformat(nodes))
+        jobids = dict()
+        #sge_option='-pe smp 8 -q default'
+        for node in nodes:
+            #node.satisfy() # This would do the job without a process-watcher.
+            jobid = node.jobid
+            self.__known[jobid] = node
+            generated_script_fn = node.execute()
+            if not generated_script_fn:
+                raise Exception('Missing generated_script_fn for Node {}'.format(node))
+                # This task is done.
+                endrun(node, 'EXIT 0')
+                self.__to_report.append(node)
                 continue
-            log.info('script_fn:%s' %repr(script_fn))
-            content = open(script_fn).read()
-            digest = hashlib.sha256(content).hexdigest()
-            jobid = 'J{}'.format(digest)
-            log.info('jobid=%s' %jobid)
-            taskObj.jobid = jobid
-            ready[jobid] = fred
-            self.__known[jobid] = fred
-        if ready:
-            # Start anything in the 'ready' queue.
-            # Note: It is safe to run this block always, but we save a
-            # call to pwatcher with 'if ready'.
-            log.debug('ready dict keys:\n%s' %pprint.pformat(ready.keys()))
-            jobids = dict()
-            #sge_option='-pe smp 8 -q default'
-            for jobid, fred in ready.iteritems():
-                generated_script_fn = fred.task().generated_script_fn
-                rundir, basename = os.path.split(os.path.abspath(generated_script_fn))
-                cmd = '/bin/bash {}'.format(basename)
-                sge_option = fred.task().parameters.get('sge_option', None)
-                job_type = fred.task().parameters.get('job_type', None)
-                job_queue = fred.task().parameters.get('job_queue', None)
-                job_nprocs = fred.task().parameters.get('job_nprocs', None)
-                jobids[jobid] = {
-                    'cmd': cmd,
-                    'rundir': rundir,
-                    # These are optional:
-                    'job_type': job_type,
-                    'job_queue': job_queue,
-                    'job_nprocs': job_nprocs,
-                    'sge_option': sge_option,
-                }
-            # Also send the default type and queue-name.
-            watcher_args = {
-                    'jobids': jobids,
-                    'job_type': self.__job_type,
-                    'job_queue': self.__job_queue,
-            }
-            with fs_based.process_watcher(self.__state_directory) as watcher:
-                result = watcher.run(**watcher_args)
-                #log.debug('Result of watcher.run()={}'.format(repr(result)))
-                submitted = result['submitted']
-                self.__running.update(submitted)
-                for jobid in set(jobids.keys()) - set(submitted):
-                    fred = ready[jobid]
-                    fred.endrun('UNSUBMITTED')
+                # For now, consider it as "submitted" and finished.
+                # (It would throw exception on error.)
 
+            rundir, basename = os.path.split(os.path.abspath(generated_script_fn))
+            cmd = '/bin/bash {}'.format(basename)
+            sge_option = node.pypetask.parameters.get('sge_option', None)
+            job_type = node.pypetask.parameters.get('job_type', None)
+            job_queue = node.pypetask.parameters.get('job_queue', None)
+            job_nprocs = node.pypetask.parameters.get('job_nprocs', None)
+            jobids[jobid] = {
+                'cmd': cmd,
+                'rundir': rundir,
+                # These are optional:
+                'job_type': job_type,
+                'job_queue': job_queue,
+                'job_nprocs': job_nprocs,
+                'sge_option': sge_option,
+            }
+        # Also send the default type and queue-name.
+        watcher_args = {
+                'jobids': jobids,
+                'job_type': self.__job_type,
+                'job_queue': self.__job_queue,
+        }
+        with fs_based.process_watcher(self.__state_directory) as watcher:
+            result = watcher.run(**watcher_args)
+            #LOG.debug('Result of watcher.run()={}'.format(repr(result)))
+            submitted = result['submitted']
+            self.__running.update(submitted)
+            for jobid in (set(jobids.keys()) - set(submitted)):
+                yield self.__known[jobid] # TODO: What should be the status for these submission failures?
+
+    def check_done(self):
+        """Yield Nodes which have finished since the last check.
+        """
         watcher_args = {
             'jobids': list(self.__running),
             'which': 'list',
         }
         with fs_based.process_watcher(self.__state_directory) as watcher:
             q = watcher.query(**watcher_args)
-        #log.debug('In alive(), result of query:%s' %repr(q))
-        global _prev_q
-        if q != _prev_q:
-            log.debug('In alive(), updated result of query:%s' %repr(q))
-            _prev_q = q
-            _prev_q = None
+        #LOG.debug('In check_done(), result of query:%s' %repr(q))
         for jobid, status in q['jobids'].iteritems():
             if status.startswith('EXIT') or status.startswith('DEAD'):
                 self.__running.remove(jobid)
-                fred = self.__known[jobid]
+                node = self.__known[jobid]
+                self.__to_report.append(node)
                 try:
-                    fred.endrun(status)
+                    endrun(node, status)
                 except Exception as e:
                     msg = 'Failed to clean-up FakeThread: jobid={} status={}'.format(jobid, repr(status))
-                    log.exception(msg)
+                    LOG.exception(msg)
                     raise
-        #log.info('len(jobq)==%d' %len(self.__jobq))
-        #log.info(''.join(traceback.format_stack()))
-        return sum(thread.is_alive() for thread in threads)
-    def join(self, threads, timeout):
-        then = datetime.datetime.now()
-        for thread in threads:
-            #assert thread is not threading.current_thread()
-            if thread.is_alive():
-                to = max(0, timeout - (datetime.datetime.now() - then).seconds)
-        # This is called only in the refreshTargets() catch, so
-        # it can simply terminate all threads.
-                thread.join(to)
-        self.notifyTerminate(threads)
-    def notifyTerminate(self, threads):
-        """Assume these are daemon threads.
-        We will attempt to join them all quickly, but non-daemon threads may
-        eventually block the program from quitting.
-        """
-        pass #self.join(threads, 1)
-        # TODO: Terminate only the jobs for 'threads'.
-        # For now, use 'known' instead of 'infer' b/c we
-        # also want to kill merely queued jobs, though that is currently difficult.
+        to_report = list(self.__to_report)
+        self.__to_report = list()
+        return to_report
+
+    def terminate(self):
         watcher_args = {
             'jobids': list(self.__running),
             'which': 'known',
         }
         with fs_based.process_watcher(self.__state_directory) as watcher:
             q = watcher.delete(**watcher_args)
-        log.debug('In notifyTerminate(), result of delete:%s' %repr(q))
+        LOG.debug('In notifyTerminate(), result of delete:%s' %repr(q))
 
-
-    # And our special methods.
-    def enqueue(self, fred):
-        self.__jobq.append(fred)
-    def __init__(self, state_directory, job_type, job_queue=None):
-        """
-        job_type and job_queue are defaults, possibly over-ridden for specific jobs.
-        Note: job_queue is a string, not a collection. If None, then it would need to
-        come via per-job settings.
-        """
+    def __init__(self, state_directory="STATE", job_type='local', job_queue=None):
         self.__state_directory = state_directory
         self.__job_type = job_type
         self.__job_queue = job_queue
-        self.__jobq = collections.deque()
-        self.__running = set()
-        self.__known = dict()
+        #self.__jobq = collections.deque()
+        self.__running = set() # jobids
+        self.__known = dict() # jobid -> Node
+        self.__to_report = list() # Nodes
 
-class MyFakePypeThreadTaskBase(PypeThreadTaskBase):
-    """Fake for PypeConcurrentWorkflow.
-    It demands a subclass, even though we do not use threads at all.
-    Here, we override everything that it overrides. PypeTaskBase defaults are fine.
+def get_unsatisfied_subgraph(g):
+    unsatg = networkx.DiGraph(g)
+    for n in g.nodes():
+        if n.satisfied():
+            unsatg.remove_node(n)
+    return unsatg
+def find_next_ready(g, node):
+    """Given a recently satisfied node,
+    return any successors with in_degree 1.
     """
-    @property
-    def nSlots(self):
-        """(I am not sure what happend if > 1, but we will not need that. ~cdunn)
-        Return the required number of slots to run, total number of slots is determined by
-        PypeThreadWorkflow.MAX_NUMBER_TASK_SLOT, increase this number by passing desired number
-        through the "parameters" argument (e.g parameters={"nSlots":2}) to avoid high computationa
-        intensive job running concurrently in local machine One can set the max number of thread
-        of a workflow by PypeThreadWorkflow.setNumThreadAllowed()
-        """
+    ready = set()
+    for n in g.successors_iter(node):
+        if 1 == g.in_degree(n):
+            ready.add(n)
+    return ready
+def find_all_roots(g):
+    """Find all nodes in g which have no predecessors.
+    """
+    roots = set()
+    for node in g:
+        if 0 == g.in_degree(node):
+            roots.add(node)
+    return roots
+
+class Workflow(object):
+    def addTask(self, pypetask):
+        node = create_node(pypetask)
+        self.graph.add_node(node)
+        for need in node.needs:
+            print "Need:", need, node
+            self.graph.add_edge(need, node)
+    def addTasks(self, tlist):
+        for t in tlist:
+            self.addTask(t)
+    def refreshTargets(self, targets=None, updateFreq=10, exitOnFailure=True, max_concurrency=2):
         try:
-            nSlots = self.parameters["nSlots"]
-        except AttributeError:
-            nSlots = 1
-        except KeyError:
-            nSlots = 1
-        return nSlots
-
-    def setMessageQueue(self, q):
-        self._queue = q
-
-    def setShutdownEvent(self, e):
-        self.shutdown_event = e
-
-    def __call__(self, *argv, **kwargv):
-        """Trap all exceptions, set fail flag, SEND MESSAGE, log, and re-raise.
-        """
-        try:
-            return self.runInThisThread(*argv, **kwargv)
-        except: # and re-raise
-            #log.exception('%s __call__ failed:\n%r' %(type(self).__name__, self))
-            self._status = pypeflow.task.TaskFail  # TODO: Do not touch internals of base class.
-            self._queue.put( (self.URL, pypeflow.task.TaskFail) )
+            self._refreshTargets(updateFreq, exitOnFailure, max_concurrency)
+        except:
+            self.tq.terminate()
             raise
-
-    def runInThisThread(self, *argv, **kwargv):
+    def _refreshTargets(self, updateFreq, exitOnFailure, max_concurrency):
+        """Return the number of failures, unless exitOnFailure.
+        - updateFreq (seconds) is really a max; we climb toward it gradually, and we reset when things change.
+        - max_concurrency is the number of simultaneous qsubs.
+        - exitOnFailure=False would allow us to keep running when parallel jobs fail.
         """
-        Similar to the PypeTaskBase.run(), but it provide some machinary to pass information
-        back to the main thread that run this task in a sepearated thread through the standard python
-        queue from the Queue module.
-
-        We expect this to be used *only* for tasks which generate run-scripts.
-        Our version does not actually run the script. Instead, we expect the script-filename to be returned
-        by run().
-        """
-        if self._queue == None:
-            raise Exception('There seems to be a case when self.queue==None, so we need to let this block simply return.')
-        self._queue.put( (self.URL, "started, runflag: %d" % True) )
-        return self.run(*argv, **kwargv)
-
-    # We must override this from PypeTaskBase b/c we do *not* produce outputs
-    # immediately.
-    def run(self, *argv, **kwargv):
-        argv = list(argv)
-        argv.extend(self._argv)
-        kwargv.update(self._kwargv)
-
-        inputDataObjs = self.inputDataObjs
-        self.syncDirectories([o.localFileName for o in inputDataObjs.values()])
-
-        outputDataObjs = self.outputDataObjs
-        parameters = self.parameters
-
-        log.info('Running task from function %s()' %(self._taskFun.__name__))
-        rtn = self._runTask(self, *argv, **kwargv)
-
-        if self.inputDataObjs != inputDataObjs or self.parameters != parameters:
-            raise TaskFunctionError("The 'inputDataObjs' and 'parameters' should not be modified in %s" % self.URL)
-            # Jason, note that this only tests whether self.parameters was rebound.
-            # If it is altered, then so is parameters, so the check would pass.
-            # TODO(CD): What is the importance of this test? Should it be fixed or deleted?
-
-        return True # to indicate that it run, since we no longer rely on runFlag
-
-    def check_missing(self):
-        timeout_s = 30
-        sleep_s = .1
-        self.syncDirectories([o.localFileName for o in self.outputDataObjs.values()]) # Sometimes helps in NFS.
-        lastUpdate = datetime.datetime.now()
-        while timeout_s > (datetime.datetime.now()-lastUpdate).seconds:
-            missing = [(k,o) for (k,o) in self.outputDataObjs.iteritems() if not o.exists]
-            if missing:
-                log.debug("%s failed to generate all outputs; %s; missing:\n%s" %(
-                    self.URL, repr(self._status),
-                    pprint.pformat(missing),
-                ))
-                #import commands
-                #cmd = 'pstree -pg -u cdunn'
-                #output = commands.getoutput(cmd)
-                #log.debug('`%s`:\n%s' %(cmd, output))
-                dirs = set(os.path.dirname(o.localFileName) for o in self.outputDataObjs.itervalues())
-                for d in dirs:
-                    log.debug('listdir(%s): %s' %(d, repr(os.listdir(d))))
-                #self._status = pypeflow.task.TaskFail
-                time.sleep(sleep_s)
-                sleep_s *= 2.0
+        assert networkx.algorithms.dag.is_directed_acyclic_graph(self.graph)
+        failures = 0
+        unsatg = get_unsatisfied_subgraph(self.graph)
+        ready = find_all_roots(unsatg)
+        queued = set()
+        init_sleep_time = 0.1
+        sleep_time = init_sleep_time
+        while unsatg:
+            # Nodes cannot be in ready or queued unless they are also in unsatg.
+            to_queue = set()
+            while ready and max_concurrency > len(queued):
+                node = ready.pop()
+                to_queue.add(node)
+                LOG.debug('will queue: {!r}'.format(node))
+            if to_queue:
+                unqueued = set(self.tq.enque(to_queue))
+                assert not unqueued, 'TODO: Decided what to do when enqueue fails.'
+                queued.update(to_queue - unqueued)
+            LOG.debug('N in queue: {}'.format(len(queued)))
+            recently_done = set(self.tq.check_done())
+            if not recently_done:
+                time.sleep(sleep_time)
+                sleep_time = sleep_time + 0.1 if (sleep_time < updateFreq) else updateFreq
+                continue
             else:
-                self._status = pypeflow.task.TaskDone
-                break
-        else:
-            log.info('timeout(%ss) in check_missing()' %timeout_s)
-            self._status = pypeflow.task.TaskFail
+                sleep_time = init_sleep_time
+            queued -= recently_done
+            #print "recently_done:", [(rd, rd.satisfied()) for rd in recently_done]
+            recently_satisfied = set(n for n in recently_done if n.satisfied())
+            recently_done -= recently_satisfied
+            #print "Now N recently_done:", len(recently_done)
+            LOG.debug('recently_satisfied: {!r}'.format(recently_satisfied))
+            for node in recently_satisfied:
+                ready.update(find_next_ready(unsatg, node))
+                unsatg.remove_node(node)
+            if recently_done:
+                msg = 'Some tasks are recently_done but not satisfied: {!r}'.format(recently_done)
+                LOG.error(msg)
+                failures += len(recently_done)
+                if exitOnFailure:
+                    raise Exception(msg)
+        assert not queued
+        assert not ready
+        return failures
+    def __init__(self, job_type, job_queue):
+        self.graph = networkx.DiGraph()
+        self.tq = PwatcherTaskQueue(state_directory='mypwatcher', job_type=job_type, job_queue=job_queue) # TODO: Inject this.
 
-    # And our own special methods.
-    def finish(self):
-        self.syncDirectories([o.localFileName for o in self.outputDataObjs.values()])
-        self._queue.put( (self.URL, self._status) )
+class NodeBase(object):
+    """Graph node.
+    Can be satisfied on demand, but usually we call execute() and later run the script.
+    """
+    def setSatisfied(self, s):
+        self.__satisfied = s
+    def workdir(self):
+        return self.wdir
+    def script_fn(self):
+        return os.path.join(self.workdir(), 'run.sh')
+    def sentinel_done_fn(self):
+        return self.script_fn() + '.done'
+    def satisfied(self):
+        """Not just done, but successful.
+        If we see the sentinel file, then we memoize True.
+        But if we finished a distributed job with exit-code 0, we do not need
+        to wait for the sentinel; we know we had success.
+        """
+        if self.__satisfied is not None:
+            return self.__satisfied
+        if os.path.exists(self.sentinel_done_fn()):
+            self.__satisfied = True
+        return self.__satisfied == True
+    def satisfy(self):
+        if self.__satisfied:
+            return
+        script_fn = self.execute()
+        if script_fn:
+            run(script_fn)
+        self.__satisfied = True
+    def execute(self):
+        actual_script_fn = self.generate_script()
+        sentinel_done_fn = self.sentinel_done_fn()
+        wdir = self.workdir()
+        rel_actual_script_fn = os.path.relpath(actual_script_fn, wdir)
+        wrapper = """#!/bin/sh
+set -vex
+cd {wdir}
+bash {rel_actual_script_fn}
+touch {sentinel_done_fn}
+""".format(**locals())
+        wrapper_fn = self.script_fn()
+        #mkdirs(os.path.dirname(wrapper_fn))
+        with open(wrapper_fn, 'w') as ofs:
+            ofs.write(wrapper)
+        return wrapper_fn
+    def generate_script(self):
+        raise NotImplementedError(repr(self))
+    def __repr__(self):
+        return 'Node({}, {})'.format(self.name, self.jobid)
+    def __init__(self, name, wdir, needs):
+        self.__satisfied = None  # satisfiable
+        self.name = name
+        self.wdir = wdir
+        self.needs = needs
+        #self.script_fn = script_fn
+        self.jobid = 'Pup{}'.format(random.randint(0, 1000000))
+class ComboNode(NodeBase):
+    """Several Nodes to be executed in sequence.
+    Only this ComboNode will be in the DiGraph, not the sub-Nodes.
+    """
+    def generate_script(self):
+        raise NotImplementedError(repr(self))
+    def __init__(self, nodes):
+        #super(ComboNode, self).__init__(name, wdir, needs)
+        self.nodes = nodes
+class PypeNode(NodeBase):
+    """
+    We will clean this up later. For now, it is pretty tightly coupled to PypeTask.
+    """
+    def generate_script(self):
+        pt = self.pypetask
+        func = pt.func
+        func(pt) # Run the function! Probably just generate a script.
+        print dir(pt)
+        generated_script_fn = getattr(pt, 'generated_script_fn', None) # by convention
+        try:
+            # Maybe we should require a script always.
+            generated_script_fn = pt.generated_script_fn
+        except Exception:
+            print pt.name, pt.URL
+            raise
+        return generated_script_fn
+    def __init__(self, name, wdir, pypetask, needs): #, script_fn):
+        super(PypeNode, self).__init__(name, wdir, needs)
+        self.pypetask = pypetask
+
+def create_node(pypetask):
+    """Given a PypeTask, return a Node for our Workflow graph.
+    """
+    needs = set()
+    node = PypeNode(pypetask.name, pypetask.wdir, pypetask, needs) #, pypetask.generated_script_fn)
+    for key, path in pypetask.outputs.iteritems():
+        PRODUCER[path] = node
+        LOG.debug('{} produces {!r}'.format(node, path))
+    for key, path in pypetask.inputs.iteritems():
+        CONSUMERS[path].add(node)
+        LOG.debug('{} consumes {!r}'.format(node, path))
+        if path in PRODUCER:
+            needs.add(PRODUCER[path])
+        else:
+            print "{} not in PRODUCER".format(path)
+    LOG.debug(' Therefore, {} needs {}'.format(node, needs))
+    return node
+
+class PypeTask(object):
+    """Adaptor from old PypeTask API.
+    """
+    def __call__(self, func):
+        self.func = func
+        return self
+    def __init__(self, inputs, outputs, parameters, TaskType, URL=None, wdir=None, name=None):
+        """Kind of a mess. inputs/outputs become actual attributes.
+        Someday, we will change how Tasks are specified.
+        """
+        self.inputs = dict(inputs)
+        self.outputs = dict(outputs)
+        self.parameters = dict(parameters)
+        self.URL = URL
+        self.wdir = wdir
+        if name:
+            self.name = name
+        else:
+            dirnames = list(os.path.dirname(os.path.normpath(o)) for o in self.outputs.values())
+            if len(dirnames) == 1:
+                d = dirnames.pop()
+                self.name = os.path.basename(d)
+                if not self.wdir:
+                    self.wdir = os.path.abspath(d)
+            else:
+                self.name = os.path.basename(self.URL)
+        for key, bn in inputs.iteritems():
+            setattr(self, key, bn)
+        for key, bn in outputs.iteritems():
+            setattr(self, key, bn)
+
+MyFakePypeThreadTaskBase = None  # just a symbol, not really used
+# A PypeLocalFile is just a string now.
+def makePypeLocalFile(p): return p
+def fn(p): return p
+# Here is the main factory.
+def PypeProcWatcherWorkflow(
+        job_type='local',
+        job_queue='dev',
+        **attributes):
+    """Factory for the workflow.
+    """
+    return Workflow(job_type=job_type, job_queue=job_queue)
+    #th = MyPypeFakeThreadsHandler('mypwatcher', job_type, job_queue)
+    #mq = MyMessageQueue()
+    #se = MyFakeShutdownEvent()
+    #return pypeflow.controller._PypeConcurrentWorkflow(URL=URL, thread_handler=th, messageQueue=mq, shutdown_event=se,
+    #        attributes=attributes)
+
+__all__ = ['PypeProcWatcherWorkflow', 'fn', 'makePypeLocalFile', 'MyFakePypeThreadTaskBase', 'PypeTask']

--- a/pypeflow/simple_pwatcher_bridge.py
+++ b/pypeflow/simple_pwatcher_bridge.py
@@ -171,7 +171,7 @@ class Workflow(object):
         node = create_node(pypetask)
         sentinel_done_fn = node.sentinel_done_fn()
         if sentinel_done_fn in self.sentinels:
-            msg = 'Found sentinel {!r} twice: {!r} and {!r}\nNote: Each task needs its own sentinel (and preferably its own run-dir).'.format(sentinel_done_fn, node, self.sentinels[sentinel_done_fn])
+            msg = 'FOUND sentinel {!r} twice: {!r} ({!r}) and {!r}\nNote: Each task needs its own sentinel (and preferably its own run-dir).'.format(sentinel_done_fn, node, pypetask, self.sentinels[sentinel_done_fn])
             raise Exception(msg)
         self.sentinels[sentinel_done_fn] = node
         self.graph.add_node(node)
@@ -364,10 +364,13 @@ class PypeTask(object):
     def __call__(self, func):
         self.func = func
         return self
-    def __init__(self, inputs, outputs, parameters, TaskType, URL=None, wdir=None, name=None):
+    def __repr__(self):
+        return 'PypeTask({!r})'.format(self.outputs)
+    def __init__(self, inputs, outputs, TaskType, parameters=None, URL=None, wdir=None, name=None):
         """Kind of a mess. inputs/outputs become actual attributes.
         Someday, we will change how Tasks are specified.
         """
+        if parameters is None: parameters = {}
         self.inputs = dict(inputs)
         self.outputs = dict(outputs)
         self.parameters = dict(parameters)

--- a/pypeflow/simple_pwatcher_bridge.py
+++ b/pypeflow/simple_pwatcher_bridge.py
@@ -516,7 +516,7 @@ def PypeProcWatcherWorkflow(
         **attributes):
     """Factory for the workflow.
     """
-    if job_type == 'string' or watcher_type == 'blocking':
+    if watcher_type == 'blocking':
         pwatcher_impl = pwatcher.blocking
     elif watcher_type == 'network_based':
         pwatcher_impl = pwatcher.network_based

--- a/pypeflow/simple_pwatcher_bridge.py
+++ b/pypeflow/simple_pwatcher_bridge.py
@@ -522,7 +522,10 @@ def PypeProcWatcherWorkflow(
         pwatcher_impl = pwatcher.network_based
     else:
         pwatcher_impl = pwatcher.fs_based
+    LOG.warning('In simple_pwatcher_bridge, pwatcher_impl={!r}'.format(pwatcher_impl))
+    LOG.info('In simple_pwatcher_bridge, pwatcher_impl={!r}'.format(pwatcher_impl))
     watcher = pwatcher_impl.get_process_watcher(watcher_directory)
+    LOG.info('job_type={!r}, job_queue={!r}'.format(job_type, job_queue))
     return Workflow(watcher, job_type=job_type, job_queue=job_queue)
     #th = MyPypeFakeThreadsHandler('mypwatcher', job_type, job_queue)
     #mq = MyMessageQueue()

--- a/pypeflow/simple_pwatcher_bridge.py
+++ b/pypeflow/simple_pwatcher_bridge.py
@@ -397,7 +397,11 @@ class PypeTask(object):
 MyFakePypeThreadTaskBase = None  # just a symbol, not really used
 # A PypeLocalFile is just a string now.
 def makePypeLocalFile(p): return p
-def fn(p): return p
+def fn(p):
+    """This must be run in the top run-dir.
+    All task funcs are executed there.
+    """
+    return os.path.abspath(p)
 # Here is the main factory.
 def PypeProcWatcherWorkflow(
         job_type='local',

--- a/pypeflow/simple_pwatcher_bridge.py
+++ b/pypeflow/simple_pwatcher_bridge.py
@@ -209,7 +209,7 @@ class Workflow(object):
                 LOG.debug('will queue: {!r}'.format(node))
             if to_queue:
                 unqueued = set(self.tq.enque(to_queue))
-                assert not unqueued, 'TODO: Decided what to do when enqueue fails.'
+                assert not unqueued, 'TODO: Decide what to do when enqueue fails.'
                 queued.update(to_queue - unqueued)
             LOG.debug('N in queue: {}'.format(len(queued)))
             recently_done = set(self.tq.check_done())

--- a/pypeflow/simple_pwatcher_bridge.py
+++ b/pypeflow/simple_pwatcher_bridge.py
@@ -334,7 +334,7 @@ class PypeNode(NodeBase):
                 'parameters': pt.parameters,
                 'python_function': pt.func_name,
         }
-        task_content = json.dumps(task_desc)
+        task_content = json.dumps(task_desc, sort_keys=True, indent=4, separators=(',', ': '))
         task_json_fn = os.path.join(pt.wdir, 'task.json')
         open(task_json_fn, 'w').write(task_content)
         cmd = '{} -m pypeflow.do_task {}'.format(sys.executable, task_json_fn)

--- a/pypeflow/util.py
+++ b/pypeflow/util.py
@@ -1,0 +1,31 @@
+import contextlib
+import logging
+import os
+
+LOG = logging.getLogger()
+
+@contextlib.contextmanager
+def cd(newdir):
+    prevdir = os.getcwd()
+    LOG.debug('CD: %r <- %r' %(newdir, prevdir))
+    os.chdir(os.path.expanduser(newdir))
+    try:
+        yield
+    finally:
+        LOG.debug('CD: %r -> %r' %(newdir, prevdir))
+        os.chdir(prevdir)
+def run(script_fn):
+    cwd, basename = os.path.split(script_fn)
+    with cd(cwd):
+        system('bash {}'.format(basename))
+def mkdirs(path):
+    if not os.path.isdir(path):
+        os.makedirs(path)
+def system(cmd):
+    LOG.info(cmd)
+    rc = os.system(cmd)
+    if rc:
+        raise Exception('{} <- {!r}'.format(rc, cmd))
+def touch(myfn):
+    cmd = 'touch {}'.format(myfn)
+    system(cmd)


### PR DESCRIPTION
`simple_pwatcher_bridge.py` is shown here as a modification of a copy of `pwatcher_bridge.py`. But actually it is a completely, nearly self-contained re-write of pypeFLOW. The basics:

### refresh loop
The refresh loop is now very simple. It also keeps the job queue filled to max_concurrency. And soon, it will combine serial Tasks into single-job ComboTasks.

### task definitions
Submitted jobs now call `python -m pypeflow.do_task task.json`. In other words, rather than generating the task bash-files on the server, we re-run Python on the remote host. A sample `task.json`:
```js
{
    "inputs": {
        "input_fofn": "/home/UNIXHOME/cdunn/repo/gh/FALCON-integrate/FALCON-examples/run/synth0/0-rawreads/raw-fofn-abs/input.fofn"
    },
    "outputs": {
        "length_cutoff": "/home/UNIXHOME/cdunn/repo/gh/FALCON-integrate/FALCON-examples/run/synth0/0-rawreads/length_cutoff",
        "raw_reads_db": "/home/UNIXHOME/cdunn/repo/gh/FALCON-integrate/FALCON-examples/run/synth0/0-rawreads/raw_reads.db",
        "rdb_build_done": "/home/UNIXHOME/cdunn/repo/gh/FALCON-integrate/FALCON-examples/run/synth0/0-rawreads/rdb_build_done",
        "run_jobs": "/home/UNIXHOME/cdunn/repo/gh/FALCON-integrate/FALCON-examples/run/synth0/0-rawreads/run_jobs.sh"
    },
    "parameters": {
        "config_fn": "/home/UNIXHOME/cdunn/repo/gh/FALCON-integrate/FALCON-examples/run/synth0/fc_run.cfg",
        "sge_option": "-pe smp 8 -q /bin/bash -c \"${CMD}\" > \"${STDOUT_FILE}\" 2> \"${STDERR_FILE}\"",
        "work_dir": "/home/UNIXHOME/cdunn/repo/gh/FALCON-integrate/FALCON-examples/run/synth0/0-rawreads"
    },
    "python_function": "falcon_kit.mains.run1.task_build_rdb"
}
```
In other words, it represents the *information* passed to `PypeTask`. (For now, we actually pass the entire `fc_run.cfg`, hidden above, but that may change.)

The reason for this `do_task` wrapper is to avoid big changes in Falcon while accomplishing some other goals. I actually prefer to generate scripts on the server, and maybe we can go back to that 
someday. I certainly do not want to discourage the use of generated bash-files, which are highly debuggable.

By passing inputs and outputs to the remote job, we allow that job to check for the readiness of inputs, which will dramatically improve our resiliency to filesystem-latency problems.

We also allow a generic way of running in `/scratch`. We could, in theory, copy both inputs and outputs, or only outputs. (David Gordon has done some testing which showed different requirements for different tasks.)

Yes, the `task.json` is similar to the `resolved-tool-contract.json`. We can discuss the differences separately. Note that with pypeflow, a task can be specified as simply as this:
```py
@PypeTask(
  inputs={'foo1': 'prev/foo1.fasta', 'foo2': 'prev/foo2.fasta'},
  outputs={'bar1': 'bar1.fasta', 'bar2': 'bar2.fasta'}
  parameters={...})
def mytask(foo1, foo2, bar1, bar2, **parameters):
  # do stuff here
```
Anyway, wrapping the pypeflow functions in pbcommand will be simpler now.

### task names, directories
We now require a unique work directory for each task. (Nesting a Task with a sub-dir of another Task is ok though.) The names are the paths relative to CWD, so we no longer need to specify URLs for uniqueness.

The jobids are still based on checksums, which might be expanded someday.

### drawbacks
I can think of a few drawbacks, none significant.
* Slower start-up for each task, because we use Python. That makes me sad, but it's insignificant for distributed tasks, or for even moderate-sized local tasks. Anyway, re-writing the workflow engine in a better language (e.g. Go or Nim) would eliminate this drawback, and would provide many other advantages. (I believe I have demonstrated here the utter simplicity of a "workflow engine". This is not much code with a simple architecture.)
* Some churn on directories and filenames. I'll help Jason adjust falcon-unzip soon.